### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ defp deps do
     {:waffle, "~> 1.0.1"},
 
     # If using S3:
-    {:ex_aws, "~> 2.1"},
+    {:ex_aws, "~> 2.1.2"},
     {:ex_aws_s3, "~> 2.0"},
     {:hackney, "~> 1.9"},
     {:sweet_xml, "~> 0.6"}


### PR DESCRIPTION
You need at least 2.1.2 of ex_aws method otherwise you'll be trying to access the sanatise/2 method before it existed.